### PR TITLE
Work around a bug in Qt4's moc processing for session.h

### DIFF
--- a/src/qtgui/session.h
+++ b/src/qtgui/session.h
@@ -1,7 +1,11 @@
 #ifndef TARQUIN_SESSION_INCLUDED
 #define TARQUIN_SESSION_INCLUDED
 
+// Q_MOC_RUN - workaround for a bug in Qt4 moc
+// https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
 #include "Workspace.hpp"
+#endif
 #include <QObject>
 #include <qwt_double_rect.h>
 #include "MRI.hpp"


### PR DESCRIPTION
Tarquin fails to build on my ubuntu 18.04 machine with an error such as

```
[ 62%] Generating moc_session.cxx
cd /home/tcfoster/src/tarquin-git/build/qtgui && /usr/lib/x86_64-linux-gnu/qt4/bin/moc @/home/tcfoster/src/tarquin-git/build/qtgui/moc_session.cxx_parameters
/usr/include/boost/predef/os/windows.h:52: Parse error at "defined"
qtgui/CMakeFiles/tarquingui.dir/build.make:115: recipe for target 'qtgui/moc_session.cxx' failed
make[2]: *** [qtgui/moc_session.cxx] Error 1
```

This appears to be a bug in qt4's version of moc; something to do with parsing boost headers and will not be fixed:

https://bugreports.qt.io/browse/QTBUG-22829

Here I've applied a minimal workaround as suggested at the bottom of the QT bug page.