### PR TITLE
GE P-file fix

### DIFF
--- a/src/common/fidio/CFIDReaderGE.cpp
+++ b/src/common/fidio/CFIDReaderGE.cpp
@@ -316,20 +316,16 @@ void tarquin::CFIDReaderGE::DiscoverOptions(std::string strFilename, CBoswell& l
         file.seekg(65032, std::ios_base::beg);
         file.read((char*)&TE, 4);
     }
-    else if ( (rdb_header_rev > 11.0) && (rdb_header_rev < 25) )
+    else if ( (rdb_header_rev > 11.0) && (rdb_header_rev <= 25.001 ) )
     {
-        int te_int;
         file.seekg(4*303, std::ios_base::beg);
-        file.read((char*)&te_int, 2);
-        TE = te_int;
+        file.read((char*)&TE, 4);
     }
-	else if ( rdb_header_rev > 25 )
-	{
-        int te_int;
+    else if ( rdb_header_rev > 25.001 )
+    {
         file.seekg(4*303-64, std::ios_base::beg);
-        file.read((char*)&te_int, 2);
-        TE = te_int;
-	}
+        file.read((char*)&TE, 4);
+    }
 
     if ( swap_end )
         TE = LongSwap(TE);


### PR DESCRIPTION
Corrects intermittent, invalid TE values when reading recent GE P-files, due to filling only 16 out of 32 bits of the int value with meaningful data (per https://groups.google.com/forum/#!topic/tarquin_users_group/2oNlETrBSgw)